### PR TITLE
Fixed Program not running when 'QuickTest.mscp' not found

### DIFF
--- a/MiniScript-cs/Program.cs
+++ b/MiniScript-cs/Program.cs
@@ -138,10 +138,16 @@ class MainClass {
 
 		Print("\n");
 
-		Print("Running quick test.\n");
-		RunFile("../../../QuickTest.mscp", true);
+		const string quickTestFilePath = "../../../QuickTest.mscp";
 
-		
+		if (File.Exists(quickTestFilePath)) {
+			Print("Running quick test.\n");
+			RunFile(quickTestFilePath, true);
+		} else {
+			Print("Quick test not found, skipping...\n");
+		}
+
+
 		if (args.Length > 0) {
 			RunFile(args[0]);
 			return;


### PR DESCRIPTION
As mentioned, the honor of the first one is mine :wink: 

I've decided to add a message when the file is not found, so you can realize it's not actually running, but that can of course be changed.

Also, as mentioned on #13, I think a better solution will be having those files as arguments, so the code doesn't know about them, but they are not run in the same way, so it's a bit more complicated to do.

Fixes #13 