### PR TITLE
Fixed running outside Unity

### DIFF
--- a/MiniScript-cs/MiniscriptTAC.cs
+++ b/MiniScript-cs/MiniscriptTAC.cs
@@ -632,6 +632,8 @@ namespace Miniscript {
 				if (moduleVars != null && moduleVars.TryGetValue(identifier, out result)) {
 					return result;
 				}
+
+#if UNITY_5_3_OR_NEWER
 				if (UnityEngine.Input.GetKey(UnityEngine.KeyCode.LeftShift)) {
 					var sb = new System.Text.StringBuilder();
 					if (moduleVars == null) sb.Append("null");
@@ -640,6 +642,7 @@ namespace Miniscript {
 					}
 					UnityEngine.Debug.Log("identifier not found in: " + sb.ToString());
 				}
+#endif
 
 				// OK, we don't have a local or module variable with that name.
 				// Check the global scope (if that's not us already).


### PR DESCRIPTION
As the title says, the code cannot be used outside Unity, just because of a small piece of code inside `MiniscriptTAC.cs`.

I've decided to use an `#if` block guard with `UNITY_5_3_OR_NEWER`, which is the lowest defined, but maybe there is a better define you want to use (either a newer version, or only inside the editor, etc)