### PR TITLE
Made function in Line not reference runtime instance

### DIFF
--- a/MiniScript-cs/MiniscriptParser.cs
+++ b/MiniScript-cs/MiniscriptParser.cs
@@ -574,6 +574,18 @@ namespace Miniscript {
 					return;
 				}
 			}
+            // If the last line was us creating and assigning a function, then we don't add a second assign
+            // op, we instead just update that line with the proper LHS
+            if(rhs is ValFunction && output.code.Count > 0)
+            {
+                TAC.Line line = output.code[output.code.Count - 1];
+                if(line.op == TAC.Line.Op.BindAssignA)
+                {
+                    line.lhs = lhs;
+                    return;
+                }
+            }
+
 			// In any other case, do an assignment statement to our lhs.
 			output.Add(new TAC.Line(lhs, TAC.Line.Op.AssignA, rhs));
 		}
@@ -625,7 +637,7 @@ namespace Miniscript {
 			// Create a function object attached to the new parse state code.
 			func.code = pendingState.code;
 			var valFunc = new ValFunction(func);
-			output.Add(new TAC.Line(null, TAC.Line.Op.BindContextOfA, valFunc));
+			output.Add(new TAC.Line(null, TAC.Line.Op.BindAssignA, valFunc));
 			return valFunc;
 		}
 

--- a/MiniScript-cs/MiniscriptTAC.cs
+++ b/MiniScript-cs/MiniscriptTAC.cs
@@ -38,7 +38,7 @@ namespace Miniscript {
 				AisaB,
 				AAndB,
 				AOrB,
-				BindContextOfA,
+				BindAssignA,
 				CopyA,
 				NotA,
 				GotoA,
@@ -132,8 +132,8 @@ namespace Miniscript {
 				case Op.AisaB:
 					text = string.Format("{0} := {1} isa {2}", lhs, rhsA, rhsB);
 					break;
-				case Op.BindContextOfA:
-					text = string.Format("{0}.outerVars = {1}", rhsA, rhsB);
+				case Op.BindAssignA:
+					text = string.Format("{0} := {1} {0}.outerVars=", rhsA, rhsB);
 					break;
 				case Op.CopyA:
 					text = string.Format("{0} := copy of {1}", lhs, rhsA);
@@ -481,12 +481,13 @@ namespace Miniscript {
 				} else {
 					// opA is something else... perhaps null
 					switch (op) {
-					case Op.BindContextOfA:
+					case Op.BindAssignA:
 						{
 							if (context.variables == null) context.variables = new ValMap();
 							ValFunction valFunc = (ValFunction)opA;
-							valFunc.outerVars = context.variables;
-							return null;
+                            return valFunc.BindAndCopy(context.variables);
+							//valFunc.outerVars = context.variables;
+							//return null;
 						}
 					case Op.NotA:
 						return opA != null && opA.BoolValue() ? ValNumber.zero : ValNumber.one;

--- a/MiniScript-cs/MiniscriptTypes.cs
+++ b/MiniScript-cs/MiniscriptTypes.cs
@@ -858,10 +858,14 @@ namespace Miniscript {
 	/// </summary>
 	public class ValFunction : Value {
 		public Function function;
-		public ValMap outerVars;	// local variables where the function was defined (usually, the module)
+		public readonly ValMap outerVars;	// local variables where the function was defined (usually, the module)
 
 		public ValFunction(Function function) {
 			this.function = function;
+		}
+		public ValFunction(Function function, ValMap outerVars) {
+			this.function = function;
+            this.outerVars = outerVars;
 		}
 
 		public override string ToString(TAC.Machine vm) {
@@ -887,6 +891,11 @@ namespace Miniscript {
 			var other = (ValFunction)rhs;
 			return function == other.function ? 1 : 0;
 		}
+
+        public ValFunction BindAndCopy(ValMap contextVariables)
+        {
+            return new ValFunction(function, contextVariables);
+        }
 
 	}
 


### PR DESCRIPTION
Previously, Line would contain a ValFunction which referenced a context's variables in it's outerVars field. This was incorrect, as the Line should never reference anything in the instance. Now the bind and assign occur in a single op, and the function in Line is copied into context