### PR TITLE
fix segfault when changing case of empty string

### DIFF
--- a/MiniScript-cpp/src/MiniScript/MiniscriptTypes.h
+++ b/MiniScript-cpp/src/MiniScript/MiniscriptTypes.h
@@ -127,8 +127,12 @@ namespace MiniScript {
 		// an ordinary, fully-fledged object you can keep around as long as you like.
 		String GetString() const { Assert(type == ValueType::String or type == ValueType::Var);
 			StringStorage *ss = (StringStorage*)(data.ref);
-			ss->retain();
-			return String(ss, false); }
+      if (data.ref) {
+  			ss->retain();
+  			return String(ss, false);
+      }
+      return String("");
+    }
 		ValueList GetList() const { Assert(type == ValueType::List); ValueList l((ValueListStorage*)(data.ref), false); return l; }
 		ValueDict GetDict() { Assert(type == ValueType::Map); if (not data.ref) data.ref = new ValueDictStorage(); ValueDict d((ValueDictStorage*)(data.ref)); d.retain(); return d; }
 


### PR DESCRIPTION
Value::GetString segfaulted when called on empty string because of missing check #41 