### PR TITLE
Minor fix: removed unnecessary constructors in Errors

### DIFF
--- a/MiniScript-cs/MiniscriptErrors.cs
+++ b/MiniScript-cs/MiniscriptErrors.cs
@@ -35,9 +35,6 @@ namespace Miniscript {
 	public class MiniscriptException: Exception {
 		public SourceLoc location;
 
-		public MiniscriptException() {
-		}
-
 		public MiniscriptException(string message) : base(message) {
 		}
 
@@ -111,8 +108,6 @@ namespace Miniscript {
 	}
 
 	public class KeyException : RuntimeException {
-		private KeyException() {}		// don't use this version
-
 		public KeyException(string key) : base("Key Not Found: '" + key + "' not found in map") {
 		}
 
@@ -154,8 +149,6 @@ namespace Miniscript {
 	}
 
 	public class UndefinedIdentifierException : RuntimeException {
-		private UndefinedIdentifierException() {}		// don't call this version!
-
 		public UndefinedIdentifierException(string ident) : base(
 			"Undefined Identifier: '" + ident + "' is unknown in this context") {
 		}

--- a/MiniScript-cs/MiniscriptTypes.cs
+++ b/MiniScript-cs/MiniscriptTypes.cs
@@ -67,14 +67,6 @@ namespace Miniscript {
 		}
 		
 		/// <summary>
-		/// Get the numeric value of this Value as an unsigned integer.
-		/// </summary>
-		/// <returns>this value, as unsigned int</returns>
-		public virtual uint UIntValue() {
-			return (uint)DoubleValue();
-		}
-		
-		/// <summary>
 		/// Get the numeric value of this Value as a single-precision float.
 		/// </summary>
 		/// <returns>this value, as a float</returns>


### PR DESCRIPTION
These constructors had a private level and were marked with the comments "do not use this version", but in order for them not to be available, it is enough not to declare them explicitly in this place.
public MiniscriptException() - also not needed.