### PR TITLE
CI builds

### DIFF
--- a/.github/workflows/linux-cpp.yml
+++ b/.github/workflows/linux-cpp.yml
@@ -1,0 +1,23 @@
+name: Linux C++ Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd MiniScript-cpp
+          make
+      - uses: actions/upload-artifact@v3  
+        with:
+          name: miniscript-linux
+          path: MiniScript-cpp/miniscript
+          if-no-files-found: error

--- a/.github/workflows/macos-cpp.yml
+++ b/.github/workflows/macos-cpp.yml
@@ -1,0 +1,23 @@
+name: MacOS C++ Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd MiniScript-cpp
+          make
+      - uses: actions/upload-artifact@v3
+        with:
+          name: miniscript-macos
+          path: MiniScript-cpp/miniscript
+          if-no-files-found: error

--- a/.github/workflows/windows-cpp.yml
+++ b/.github/workflows/windows-cpp.yml
@@ -1,0 +1,23 @@
+name: Windows C++ Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd MiniScript-cpp/src
+          cl /EHsc /wd4068 *.cpp MiniScript/*.cpp /Feminiscript.exe
+      - uses: actions/upload-artifact@v3  
+        with:
+          name: miniscript-windows
+          path: MiniScript-cpp/src/miniscript.exe
+          if-no-files-found: error

--- a/.github/workflows/windows-cpp.yml
+++ b/.github/workflows/windows-cpp.yml
@@ -13,10 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
+      - uses: ilammy/msvc-dev-cmd@v1
         run: |
           cd MiniScript-cpp/src
           cl /EHsc /wd4068 *.cpp MiniScript/*.cpp /Feminiscript.exe
-      - uses: actions/upload-artifact@v3  
+      - uses: actions/upload-artifact@v3
         with:
           name: miniscript-windows
           path: MiniScript-cpp/src/miniscript.exe

--- a/.github/workflows/windows-cpp.yml
+++ b/.github/workflows/windows-cpp.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-      - uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@v1
         run: |
           cd MiniScript-cpp/src
           cl /EHsc /wd4068 *.cpp MiniScript/*.cpp /Feminiscript.exe

--- a/.github/workflows/windows-cpp.yml
+++ b/.github/workflows/windows-cpp.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
+      - uses: ilammy/msvc-dev-cmd@v1
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        uses: ilammy/msvc-dev-cmd@v1
         run: |
           cd MiniScript-cpp/src
           cl /EHsc /wd4068 *.cpp MiniScript/*.cpp /Feminiscript.exe

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,6 @@
 DerivedData
 *.xcodeproj
 .vs
-
+.vscode
 
 


### PR DESCRIPTION
Windows and Linux amd64 builds work, can try and set up arm and 32bit builds for those if that's a thing you want to support

As for macOS (broken right now!), running `make` results in `nullptr` being an undefined identifier -- don't know much about C/pp, but it seems like the compiler is too old? And the xcodeproj (its in your `.gitignore`) file is missing, so can't try to use that