### PR TITLE
[C#][GHA] Add correct version to project file & Only release new Nuget packages with every new version

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,6 +2,8 @@ name: Publish on Github Packages
 
 on:
   workflow_run:
+    branches:
+      - master
     workflows:
       - "Build .NET project"
     types:
@@ -11,10 +13,43 @@ permissions:
   packages: write
 
 jobs:
-  nuget:
-    name: Nuget
+  check_nuget:
+    name: Check if a new Nuget release is required
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      release: ${{ steps.compare.outputs.new-version }}
+
+    defaults:
+      run:
+        working-directory: MiniScript-cs
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get latest nuget package version
+        id: nuget-ver
+        run: |
+          export NUGET_VER=$(gh api -H "Accept: application/vnd.github+json" /users/JoeStrout/packages/nuget/Miniscript/versions | jq '.[0].name' | tr -d '"')
+          echo "version=${NUGET_VER}" >> $GITHUB_OUTPUT
+
+      - name: Compare vs current version
+        id: compare
+        run: |
+          export CURRENT_VER=$(grep -e "Version" Miniscript.csproj | awk -F'>' '{print $2}' | awk -F'<' '{print $1}')
+          [[ "${{ steps.nuget-ver.outputs.version }}" != "$CURRENT_VER" ]] \
+            && echo "new-version=true" \
+            || echo "new-version=false" \
+            >> $GITHUB_OUTPUT
+
+  nuget:
+    name: Release Nuget package
+    runs-on: ubuntu-latest
+    needs: check_nuget
+    if: ${{ github.event.workflow_run.conclusion == 'success' && needs.check_nuget.outputs.release == 'true' }}
     
     defaults:
       run:

--- a/MiniScript-cs/Miniscript.csproj
+++ b/MiniScript-cs/Miniscript.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Miniscript</RootNamespace>
     <AssemblyName>Miniscript</AssemblyName>
     <TargetFrameworks>net45;net5.0</TargetFrameworks>
-    <ProductVersion>8.0.30703</ProductVersion>
+    <Version>1.5.1</Version>
     <RepositoryUrl>https://github.com/JoeStrout/miniscript</RepositoryUrl>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">


### PR DESCRIPTION
This PR fixes the recent workflow errors which were caused by trying to publish the same version twice.

Now a Nuget package will only be released when the version in the project file changed.