### PR TITLE
MiniScript-cpp: Revamp Makefile, allow installation to a custom location, improve build performance

### DIFF
--- a/MiniScript-cpp/Makefile
+++ b/MiniScript-cpp/Makefile
@@ -1,15 +1,54 @@
 CC=gcc
-CFLAGS=-c -Isrc -Isrc/editline -Isrc/MiniScript
+CXX=g++
+RM=rm -f
+
+INC=-Isrc -Isrc/editline -Isrc/MiniScript
+
+CFLAGS=-fsigned-char $(INC)
+CXXFLAGS=-std=c++14 $(INC)
+CPPFLAGS=-MMD -MP
 LIBS=-lstdc++ -lm
 
-miniscript: src/*.h src/*.cpp src/MiniScript/*.h src/MiniScript/*.cpp src/editline/*.h src/editline/*.c
-	$(CC) -o miniscript src/*.cpp src/editline/complete.c src/editline/editline.c src/editline/sysunix.c src/MiniScript/*.cpp -Isrc -Isrc/editline -Isrc/MiniScript -fsigned-char $(LIBS)
+CONFIG:=Release
+ifeq ($(CONFIG), Debug)
+CFLAGS:=$(CFLAGS) -O0 -ggdb3
+CXXFLAGS:=$(CXXFLAGS) -O0 -ggdb3
+else
+CFLAGS:=$(CFLAGS) -Ofast
+CXXFLAGS:=$(CXXFLAGS) -Ofast
+endif
 
-.PHONY: clean
+TOOL_EXE=miniscript
+PREFIX=/usr/local/bin
 
-install:
-	chmod ugo+x miniscript
-	mv miniscript /usr/local/bin
+TOOL_SRC=src/ShellIntrinsics.cpp src/OstreamSupport.cpp src/main.cpp
+TOOL_OBJ=$(TOOL_SRC:.cpp=.o)
+
+MINISCRIPT_SRC=src/MiniScript/SplitJoin.cpp src/MiniScript/MiniscriptInterpreter.cpp src/MiniScript/MiniscriptIntrinsics.cpp src/MiniScript/SimpleString.cpp src/MiniScript/QA.cpp src/MiniScript/MiniscriptParser.cpp src/MiniScript/UnicodeUtil.cpp src/MiniScript/MiniscriptTAC.cpp src/MiniScript/MiniscriptTypes.cpp src/MiniScript/List.cpp src/MiniScript/SimpleVector.cpp src/MiniScript/MiniscriptKeywords.cpp src/MiniScript/UnitTest.cpp src/MiniScript/Dictionary.cpp src/MiniScript/MiniscriptLexer.cpp
+MINISCRIPT_OBJ=$(MINISCRIPT_SRC:.cpp=.o)
+
+EDITLINE_SRC=src/editline/complete.c src/editline/editline.c src/editline/sysunix.c
+EDITLINE_OBJ=$(EDITLINE_SRC:.c=.o)
+
+OBJS=$(TOOL_OBJ) $(MINISCRIPT_OBJ) $(EDITLINE_OBJ)
+DEPS=$(OBJS:.o=.d)
+
+.PHONY: all clean distclean install
+
+all: $(TOOL_EXE)
+
+$(TOOL_EXE): $(OBJS)
+	$(CXX) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
 
 clean:
-	rm -f miniscript /usr/local/bin/miniscript
+	$(RM) $(OBJS) $(DEPS)
+
+distclean: clean
+	$(RM) $(TOOL_EXE)
+	$(RM) $(PREFIX)/$(TOOL_EXE)
+
+install: $(TOOL_EXE)
+	chmod +x $(TOOL_EXE)
+	install $(TOOL_EXE) $(PREFIX)
+
+-include $(DEPS)


### PR DESCRIPTION
Added Debug/Release configs, added ability to specify a custom install location, brought in some dependency handling etc., but I've tried to keep it so no extra tooling is needed, and running plain old `make` or `make install` should Just Work ™️

You can also do `make CONFIG=Debug` and it will build with optimisations off and debug symbols in.

Works on macos with the built-in tooling, should work just fine on Linux; I haven't used anything fancy. Most of it is just `make` features
