### PR TITLE
Fix nuget version comparison for Github Actions

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Get latest nuget package version
         id: nuget-ver
         run: |
-          export NUGET_VER=$(gh api -H "Accept: application/vnd.github+json" /users/${{ github.repository_owner }}/packages/nuget/Miniscript/versions | jq '.[0].name' | tr -d '"')
+          export NUGET_VER=$(gh api -H "Accept: application/vnd.github+json" /users/${{ github.repository_owner }}/packages/nuget/Miniscript/versions | jq '.[0].name' | tr -d '"' | awk -F'-' '{print $1}')
           echo "version=${NUGET_VER}" >> $GITHUB_OUTPUT
 
       - name: Compare vs current version


### PR DESCRIPTION
Recently I saw a lot of workflow errors on the discord server and was wondering what happened.
I took a look and figured out that the workflow currently tries to create a new release package for every new commit, because the version is always different from the latest preview package.

This PR fixes this issue by stripping the suffix from the latest Nuget version before the comparison happens.