### PR TITLE
Eliminate stringop-overflow warning

### DIFF
--- a/MiniScript-cpp/src/MiniScript/SimpleString.cpp
+++ b/MiniScript-cpp/src/MiniScript/SimpleString.cpp
@@ -286,7 +286,7 @@ namespace MiniScript {
 		Assert(s == "foooobarbazaroooo");
 		
 		s = "another simple String";
-		char *str = new char[22];
+		char *str = new char[23];
 		strcpy(str,"an array of characters");
 		s.takeoverBuffer(str);
 		Assert(s == "an array of characters");


### PR DESCRIPTION
This should eliminate the warning when running `make`:

```
src/MiniScript/SimpleString.cpp: In member function ‘virtual void MiniScript::TestString::Run()’:
src/MiniScript/SimpleString.cpp:290:23: warning: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ writing 23 bytes into a region of size 22 overflows the destination [-Wstringop-overflow=]
  290 |                 strcpy(str,"an array of characters");
      |                 ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/MiniScript/SimpleString.cpp:289:40: note: destination object of size 22 allocated by ‘operator new []’
  289 |                 char *str = new char[22];
      |                                        ^
```