### PR TITLE
Output .EXE near libs/

### DIFF
--- a/MiniScript-cpp/README.md
+++ b/MiniScript-cpp/README.md
@@ -28,7 +28,7 @@ Other make options you can use:
 
 Install the [Visual Studio Command-Line Tools](https://docs.microsoft.com/en-us/cpp/build/walkthrough-compiling-a-native-cpp-program-on-the-command-line?view=vs-2019), and then you can build by `cd`ing into the `src` directory, and using this command:
 
-`cl /EHsc /wd4068 *.cpp MiniScript/*.cpp whereami/*.c /Feminiscript.exe`
+`cl /EHsc /wd4068 *.cpp MiniScript/*.cpp whereami/*.c /Fe..\miniscript.exe`
 
 The output will be called `miniscript.exe` and located in the same directory.
 


### PR DESCRIPTION
In Windows instructions, suggest a build command that outputs the resulting .exe in the folder that contains `libs/`, so MiniScript finds them even with a provided script file.