### PR TITLE
Increment linenum in multi-line strings

### DIFF
--- a/MiniScript-cpp/src/MiniScript/MiniscriptLexer.cpp
+++ b/MiniScript-cpp/src/MiniScript/MiniscriptLexer.cpp
@@ -219,6 +219,14 @@ namespace MiniScript {
 						gotEndQuote = true;
 						break;
 					}
+				} else if (c == '\n') {
+					ls->lineNum++;
+				} else if (c == '\r') {
+					// Careful; DOS may use \r\n, so we need to check for that too.
+					if (ls->positionB < ls->inputLengthB && ls->input[ls->positionB] == '\n') {
+						ls->positionB++;
+					}
+					ls->lineNum++;
 				}
 			}
 			if (!gotEndQuote) LexerException("missing closing quote (\")").raise();
@@ -403,6 +411,11 @@ namespace MiniScript {
 		check(Lexer::LastToken("x = [\"foo\", \"//bar\"]"), Token::Type::RSquare);
 		check(Lexer::LastToken("print 1 // line 1\nprint 2"), Token::Type::Number, "2");
 		check(Lexer::LastToken("print \"Hi\"\"Quote\" // foo bar"), Token::Type::String, "Hi\"Quote");
+		
+		lex = Lexer("\"\n\"");
+		check(lex.Dequeue(), Token::Type::String, "\n");
+		Assert(lex.lineNum() == 2);
+		Assert(lex.atEnd());
 	}
 	
 	RegisterUnitTest(TestLexer);

--- a/MiniScript-cs/Miniscript.csproj
+++ b/MiniScript-cs/Miniscript.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Miniscript</RootNamespace>
     <AssemblyName>Miniscript</AssemblyName>
-    <TargetFrameworks>net45;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;net5.0;net7.0</TargetFrameworks>
     <VersionPrefix>1.5.1</VersionPrefix>
     <RepositoryUrl>https://github.com/JoeStrout/miniscript</RepositoryUrl>
   </PropertyGroup>

--- a/MiniScript-cs/MiniscriptLexer.cs
+++ b/MiniScript-cs/MiniscriptLexer.cs
@@ -236,6 +236,14 @@ namespace Miniscript {
 							gotEndQuote = true;
 							break;
 						}
+					} else if (c == '\n') {
+						lineNum++;
+					} else if (c == '\r') {
+						// Careful; DOS may use \r\n, so we need to check for that too.
+						if (position < inputLength && input[position] == '\n') {
+							position++;
+						}
+						lineNum++;
 					}
 				}
 				if (!gotEndQuote) throw new LexerException("missing closing quote (\")");
@@ -425,6 +433,11 @@ namespace Miniscript {
 			Check(LastToken("x = [\"foo\", \"//bar\"]"), Token.Type.RSquare);
 			Check(LastToken("print 1 // line 1\nprint 2"), Token.Type.Number, "2");			
 			Check(LastToken("print \"Hi\"\"Quote\" // foo bar"), Token.Type.String, "Hi\"Quote");			
+			
+			lex = new Lexer("\"\n\"");
+			Check(lex.Dequeue(), Token.Type.String, "\n");
+			CheckLineNum(lex.lineNum, 2);
+			UnitTest.ErrorIf(!lex.AtEnd, "AtEnd not set when it should be");
 		}
 	}
 }


### PR DESCRIPTION
Hey, Joe. Source files containing multi-line strings report wrong line numbers on errors because MiniScript thinks that string literals are always 1 line. This patch fixes that by incrementing line numbers inside multi-line string literals.