### PR TITLE
MiniScript: Fix bitwise operation behaviour.

### DIFF
--- a/MiniScript-cpp/src/MiniScript/MiniscriptIntrinsics.cpp
+++ b/MiniScript-cpp/src/MiniScript/MiniscriptIntrinsics.cpp
@@ -11,7 +11,7 @@
 #include "MiniscriptTAC.h"
 #include "UnicodeUtil.h"
 #include "SplitJoin.h"
-#include <math.h>
+#include <cmath>
 #include <ctime>
 #include <algorithm>
 
@@ -72,23 +72,33 @@ namespace MiniScript {
 		if (x == 1.0) return IntrinsicResult(atan(y));
 		return IntrinsicResult(atan2(y, x));
 	}
+
+	static std::pair<bool, uint64_t> doubleToUnsignedSplit(double val) {
+		return { std::signbit(val), std::abs(val) };
+	}
 	
 	static IntrinsicResult intrinsic_bitAnd(Context *context, IntrinsicResult partialResult) {
-		Value i = context->GetVar("i");
-		Value j = context->GetVar("j");
-		return IntrinsicResult(i.IntValue() & j.IntValue());
+		auto i = doubleToUnsignedSplit(context->GetVar("i").DoubleValue());
+		auto j = doubleToUnsignedSplit(context->GetVar("j").DoubleValue());
+		auto sign = i.first & j.first;
+		double val = i.second & j.second;
+		return IntrinsicResult(sign ? -val : val);
 	}
 	
 	static IntrinsicResult intrinsic_bitOr(Context *context, IntrinsicResult partialResult) {
-		Value i = context->GetVar("i");
-		Value j = context->GetVar("j");
-		return IntrinsicResult(i.IntValue() | j.IntValue());
+		auto i = doubleToUnsignedSplit(context->GetVar("i").DoubleValue());
+		auto j = doubleToUnsignedSplit(context->GetVar("j").DoubleValue());
+		auto sign = i.first | j.first;
+		double val = i.second | j.second;
+		return IntrinsicResult(sign ? -val : val);
 	}
 	
 	static IntrinsicResult intrinsic_bitXor(Context *context, IntrinsicResult partialResult) {
-		Value i = context->GetVar("i");
-		Value j = context->GetVar("j");
-		return IntrinsicResult(i.IntValue() ^ j.IntValue());
+		auto i = doubleToUnsignedSplit(context->GetVar("i").DoubleValue());
+		auto j = doubleToUnsignedSplit(context->GetVar("j").DoubleValue());
+		auto sign = i.first ^ j.first;
+		double val = i.second ^ j.second;
+		return IntrinsicResult(sign ? -val : val);
 	}
 
 	static IntrinsicResult intrinsic_char(Context *context, IntrinsicResult partialResult) {

--- a/MiniScript-cpp/src/MiniScript/MiniscriptTypes.cpp
+++ b/MiniScript-cpp/src/MiniScript/MiniscriptTypes.cpp
@@ -225,12 +225,19 @@ namespace MiniScript {
 		}
 	}
 	
-	long Value::IntValue() {
-		if (type == ValueType::Number) return data.number;
-		return 0;
+	int32_t Value::IntValue() const noexcept {
+		return type == ValueType::Number ? data.number : 0;
+	}
+
+	uint32_t Value::UIntValue() const noexcept {
+		return type == ValueType::Number ? data.number : 0;
+	}
+
+	float Value::FloatValue() const noexcept {
+		return type == ValueType::Number ? data.number : 0;
 	}
 	
-	bool Value::BoolValue() {
+	bool Value::BoolValue() const noexcept {
 		switch (type) {
 			case ValueType::Number:
 				// Any nonzero value is considered true, when treated as a bool.

--- a/MiniScript-cpp/src/MiniScript/MiniscriptTypes.h
+++ b/MiniScript-cpp/src/MiniScript/MiniscriptTypes.h
@@ -13,6 +13,8 @@
 #include "List.h"
 #include "Dictionary.h"
 
+#include <cstdint>
+
 namespace MiniScript {
 	
 	extern const String VERSION;
@@ -127,11 +129,13 @@ namespace MiniScript {
 		inline ~Value() { if (usesRef()) release(); }
 
 		// conversions
-		String ToString(Machine *vm=NULL);
+		String ToString(Machine *vm=nullptr);
 		String CodeForm(Machine *vm, int recursionLimit=-1);
-		long IntValue();
-		bool BoolValue();
-		double DoubleValue() const { return type == ValueType::Number ? data.number : 0; }
+		int32_t IntValue() const noexcept;
+		uint32_t UIntValue() const noexcept;
+		float FloatValue() const noexcept;
+		bool BoolValue() const noexcept;
+		double DoubleValue() const noexcept { return type == ValueType::Number ? data.number : 0; }
 		
 		// Looking up the inner value, *without* conversion.
 		// Note that these do NOT return a temp string/list/dict; they return

--- a/MiniScript-cpp/src/ShellIntrinsics.h
+++ b/MiniScript-cpp/src/ShellIntrinsics.h
@@ -10,7 +10,7 @@
 #define SHELLINTRINSICS_H
 
 #include "MiniScript/MiniscriptTypes.h"
-#if _WIN32 || _WIN64
+#if _WIN32
 	#define useEditline 0
 #else
 	#include "editline.h"

--- a/MiniScript-cs/MiniscriptIntrinsics.cs
+++ b/MiniScript-cs/MiniscriptIntrinsics.cs
@@ -333,6 +333,10 @@ namespace Miniscript {
 				return new Intrinsic.Result(Math.Atan2(y, x));
 			};
 
+			Func<double, Tuple<bool, ulong>> doubleToUnsignedSplit = (val) => {
+				return new Tuple<bool, ulong>(Math.Sign(val) == -1, (ulong)Math.Abs(val));
+			};
+
 			// bitAnd
 			//	Treats its arguments as integers, and computes the bitwise
 			//	`and`: each bit in the result is set only if the corresponding
@@ -346,11 +350,13 @@ namespace Miniscript {
 			f.AddParam("i", 0);
 			f.AddParam("j", 0);
 			f.code = (context, partialResult) => {
-				int i = context.GetLocalInt("i");
-				int j = context.GetLocalInt("j");
-				return new Intrinsic.Result(i & j);
-			};
-			
+				var i = doubleToUnsignedSplit(context.GetLocalDouble("i"));
+				var j = doubleToUnsignedSplit(context.GetLocalDouble("j"));
+				var sign = i.Item1 & j.Item1;
+				double val = i.Item2 & j.Item2;
+				return new Intrinsic.Result(sign ? -val : val);
+            };
+
 			// bitOr
 			//	Treats its arguments as integers, and computes the bitwise
 			//	`or`: each bit in the result is set if the corresponding
@@ -364,9 +370,11 @@ namespace Miniscript {
 			f.AddParam("i", 0);
 			f.AddParam("j", 0);
 			f.code = (context, partialResult) => {
-				int i = context.GetLocalInt("i");
-				int j = context.GetLocalInt("j");
-				return new Intrinsic.Result(i | j);
+				var i = doubleToUnsignedSplit(context.GetLocalDouble("i"));
+				var j = doubleToUnsignedSplit(context.GetLocalDouble("j"));
+				var sign = i.Item1 | j.Item1;
+				double val = i.Item2 | j.Item2;
+                return new Intrinsic.Result(sign ? -val : val);
 			};
 			
 			// bitXor
@@ -382,10 +390,12 @@ namespace Miniscript {
 			f.AddParam("i", 0);
 			f.AddParam("j", 0);
 			f.code = (context, partialResult) => {
-				int i = context.GetLocalInt("i");
-				int j = context.GetLocalInt("j");
-				return new Intrinsic.Result(i ^ j);
-			};
+                var i = doubleToUnsignedSplit(context.GetLocalDouble("i"));
+                var j = doubleToUnsignedSplit(context.GetLocalDouble("j"));
+                var sign = i.Item1 ^ j.Item1;
+                double val = i.Item2 ^ j.Item2;
+                return new Intrinsic.Result(sign ? -val : val);
+            };
 			
 			// char
 			//	Gets a character from its Unicode code point.

--- a/TestSuite.txt
+++ b/TestSuite.txt
@@ -1292,10 +1292,24 @@ print log(50, 5)
 print bitAnd(14, 7)	// binary 1110 & 0111 = 0110
 print bitOr(14, 7)	// binary 1110 | 0111 = 1111
 print bitXor(14, 7)	// binary 1110 ^ 0111 = 1001
+print bitAnd(1099511627774, 962072674207) // too many bits. use your calc.
+print bitAnd(-224883, 222678)
+print bitAnd(-224883, -222678)
+print bitOr(17592186044414, 87960930222009)
+print bitOr(-12345, 54321)
+print bitXor(192763993632181, 168643457158587)
+print bitXor(-23453455467, -76598387347)
 ----------------------------------------------------------------------
 6
 15
 9
+962072674206
+222290
+-222290
+87960930222079
+-62521
+59579786731534
+88591169272
 ======================================================================
 ==== Check various edge cases with function calls and implicit results.
 func = function


### PR DESCRIPTION
We now convert double types into 64-bit integers in both C# and C++. The sign bit is also processed separately. This ensures consistent behaviour.

A few minor bits of code cleanup that I noticed have also been made:

* made the number-grabbing functions `const noexcept`.
* changed a `NULL` to `nullptr`.
* removed the WIN64 ifdef check. WIN32 is **always** defined.
* corrected header inclusion to use `cmath` - this is C++ after all.

closes #96