### PR TITLE
Exec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,11 @@ DerivedData
 .vs
 obj/
 bin/
+
+# Build Artifacts
+.vscode
+CMakeFiles
+cmake_install.cmake
+CMakeCache.txt
+Makefile
+miniscript


### PR DESCRIPTION
`exec` takes a single `path` parameter that will be executed by the OS.

`path` is used to fork a child process.  After the child process completes, the parent generates a map to return to the user:

```miniscript
{
    "stdout": "The standard output stream from the child process.",
    "stderr": "The standard error stream from the child process.",
    "returnCode": 256, // The return code from the child process.
}
```