### PR TITLE
Fixing comment-related bugs in /sys/lib/grfon

### DIFF
--- a/MiniScript-cpp/lib/grfon.ms
+++ b/MiniScript-cpp/lib/grfon.ms
@@ -107,15 +107,13 @@ end function
 whitespace = " " + char(9) + cr + lf
 Parser._skipWhitespace = function
 	while self._p < self._sourceLen
-		c = self.source[self._p]
-		if c == "/" and self._p+1 < self._sourceLen and self.source[self._p+1] == "/" then
-			// comment; skip to end of line
-			self._p = self._p + 1
+		if self.source[self._p : self._p + 2] == "//" then
 			self._skipToEOL
+		else if whitespace.indexOf(self.source[self._p]) != null then
+			self._p = self._p + 1
+		else
 			break
 		end if
-		if whitespace.indexOf(c) == null then break
-		self._p = self._p + 1
 	end while
 end function
 
@@ -313,24 +311,33 @@ runUnitTests = function
 	
 	// Note: the order of key/value pairs in a dictionary is undefined.
 	// So, it's a bit hard to unit test, as the order in which they appear
-	// in GRFON isn't defined either.  I've coded an order below which 
-	// currently works, but if these tests ever fail, manual inspection will
-	// be needed to see if they are true failures, or just a new order.
+	// in GRFON isn't defined either.
 	s = toGRFON([1, 2, "foo"], true)
 	assertEqual s, "1; 2; foo";
 	s = toGRFON([1, 2, "foo"])
 	assertEqual escape(s), "1\n2\nfoo"
 	d = {1:"one", 2:"two", "three":"san"}
 	s = toGRFON(d, true)
-	assertEqual s, "1: one; three: san; 2: two"
+	//assertEqual s, "1: one; 2: two; three: san"
+	assertEqual s.indexOf("1: one") != null, true
+	assertEqual s.indexOf("2: two") != null, true
+	assertEqual s.indexOf("three: san") != null, true
+	assertEqual s.split(";").len, 3
 	s = toGRFON(d)
-	assertEqual s, unescape("1: one\nthree: san\n2: two")
+	//assertEqual s, unescape("1: one\n2: two\nthree: san")
+	assertEqual s.indexOf("1: one") != null, true
+	assertEqual s.indexOf("2: two") != null, true
+	assertEqual s.indexOf("three: san") != null, true
+	assertEqual s.split(unescape("\n")).len, 3
 	d = [0, [1], [1,2]]
 	s = toGRFON(d)
 	assertEqual s, unescape("0\n{\n  1\n}\n{\n  1\n  2\n}")
 	d = {"foo":[1, 2, 3], "bar":"baz"}
 	s = toGRFON(d, true)
-	assertEqual s, "bar: baz; foo: {1; 2; 3}"
+	//assertEqual s, "foo: {1; 2; 3}; bar: baz"
+	assertEqual s.indexOf("foo: {1; 2; 3}") != null, true
+	assertEqual s.indexOf("bar: baz") != null, true
+	assertEqual s.split(";").len, 4
 	
 	p = new Parser
 	p.init("   true")
@@ -352,6 +359,14 @@ runUnitTests = function
 	// is rather arbitrary.  But we choose to have it return a map
 	assertEqual parse("{}"), {}
 	assertEqual parse("1; 2; {}; 4"), [1, 2, {}, 4]
+	
+	// Fixed bug with 3 lines of comments throwing Runtime Error
+	assertEqual parse("//" + cr + "foo:42"), {"foo": 42}
+	assertEqual parse("//" + cr + "//" + cr + "foo:42"), {"foo": 42}
+	assertEqual parse("//" + cr + "//" + cr + "//" + cr + "foo:42"), {"foo": 42}
+	
+	// Fixing bug with two line breaks after a comment making the "{" character a part of the key
+	assertEqual parse("//" + cr + cr + "{foo:42}"), {"foo": 42}
 	
 	if errorCount == 0 then
 		print "All tests passed.  Fus Ro Dah!"


### PR DESCRIPTION
Fixing these bugs:

Runtime Error after three or more comment lines:
```c
> import "grfon"
> s = ("//" + char(13)) * 2 + "foo: 42"
> grfon.parse s
{"foo": 42}
> s = ("//" + char(13)) * 3 + "foo: 42"
> grfon.parse s
Runtime Error: can't set an indexed element in this type [grfon.ms line 164]
```

Left `{` becomes part of the key after a comment and two line breaks:
```c
> import "grfon"
> grfon.parse "//" + char(13) + "{foo:42}"            
{"foo": 42}
> grfon.parse "//" + char(13) + char(13) + "{foo:42}"
{"{foo": 42}
```

(Corresponding PR sent to [minimicro-sysdisk](https://github.com/JoeStrout/minimicro-sysdisk))
