### PR TITLE
Update dotnet build task to build on 7.0

### DIFF
--- a/.github/workflows/cs-build-project.yml
+++ b/.github/workflows/cs-build-project.yml
@@ -18,7 +18,7 @@ jobs:
       
       - uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 7.0.x
       
       - name: Build
         run: dotnet build -c Release


### PR DESCRIPTION
dotnet won't build a project targeting 7.0 on 5.0.

(If you'd prefer to remove the GitHub Actions workflows entirely I can do that instead.)