### PR TITLE
Fix multiple files execution with -i

### DIFF
--- a/MiniScript-cpp/src/main.cpp
+++ b/MiniScript-cpp/src/main.cpp
@@ -317,6 +317,7 @@ int main(int argc, const char * argv[]) {
 			AddScriptPathVar(arg.c_str());
 			int rc = DoScriptFile(interp, arg);
 			if (!launchReplAfterScript) return rc;
+			break;
 		} else {
 			PrintHeaderInfo();
 			return ReturnErr(String("Unknown option: ") + arg);


### PR DESCRIPTION
I introduced a bug that caused executing every argument on the command line when `-i` switch is provided:

```sh
$ cat >xx.ms
print shellArgs

$ miniscript xx.ms xx.ms xx.ms 
["xx.ms", "xx.ms", "xx.ms"]

$ miniscript -i xx.ms xx.ms xx.ms 
["xx.ms", "xx.ms", "xx.ms"]
["xx.ms", "xx.ms"]
["xx.ms"]

...
```

This PR should fix it.