### PR TITLE
Free data on RawData.resize(0)

### DIFF
--- a/MiniScript-cpp/src/ShellIntrinsics.cpp
+++ b/MiniScript-cpp/src/ShellIntrinsics.cpp
@@ -104,15 +104,16 @@ public:
 	}
 	virtual ~RawDataHandleStorage() { free(data); }
 	void resize(size_t newSize) {
-		if (data) {
+		if (newSize == 0) {
+			free(data);
+			data = nullptr;
+			dataSize = 0;
+		} else {
 			void *newData = realloc(data, newSize);
 			if (newData) {
 				data = newData;
 				dataSize = newSize;
 			}
-		} else {
-			data = malloc(newSize);
-			if (data) dataSize = newSize;
 		}
 	}
 


### PR DESCRIPTION
In the previous `RawData` patch I've introduced UB by `realloc` to size `0`. On my Linux it core-dumped on this:

```
> r = new RawData
> r.resize 0
> r.resize 0
> r.resize 0
free(): double free detected in tcache 2
Aborted (core dumped)
```

This PR should fix it.