### PR TITLE
Fix rawdata utf8 incompat

### DIFF
--- a/MiniScript-cpp/rdTest.ms
+++ b/MiniScript-cpp/rdTest.ms
@@ -65,4 +65,11 @@ testRawData = function
 	r.setUtf8 0, "hello world"
 	qa.assertEqual r.utf8(0), "hello w"
 	
+	r = new RawData
+	qa.assertEqual r.utf8, null
+	r.resize 0
+	qa.assertEqual r.utf8, null
+	r.resize
+	r.resize 0
+	qa.assertEqual r.utf8, null
 end function

--- a/MiniScript-cpp/src/ShellIntrinsics.cpp
+++ b/MiniScript-cpp/src/ShellIntrinsics.cpp
@@ -1112,6 +1112,9 @@ static IntrinsicResult intrinsic_rawDataUtf8(Context *context, IntrinsicResult p
 	long nBytes = context->GetVar("bytes").IntValue();
 	const char *data = (const char *)rawDataGetBytes(self, offset, nBytes, rdnaNull);
 	if (!data) return IntrinsicResult::Null;
+	Value dataWrapper = self.Lookup(_handle);
+	RawDataHandleStorage *storage = (RawDataHandleStorage*)dataWrapper.data.ref;
+	if (storage->dataSize == 0) return IntrinsicResult::Null;
 	String result(data, nBytes);
 	return IntrinsicResult(result);
 }


### PR DESCRIPTION
On Mini Micro empty RawData's `.utf8` returns `null` either when no storage is allocated or resized to 0. Fixing C++ implementation to accord.