### PR TITLE
[build] Honor project installation by preserving headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,4 +133,15 @@ if(MINISCRIPT_BUILD_TESTING)
 	endif()
 endif()
 
-install(TARGETS miniscript-cpp minicmd)
+include(GNUInstallDirs)
+install(
+    TARGETS miniscript-cpp minicmd
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(
+	FILES ${MINISCRIPT_HEADERS}
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/MiniScript
+)


### PR DESCRIPTION
Greetings! 

The current CMakeLists.txt is not installing those headers provided by the project, only the library and application:

```
$ wget https://github.com/JoeStrout/miniscript/archive/refs/tags/v1.6.2.tar.gz
$ tar zxf v1.6.2.tar.gz && cd miniscript-1.6.2/
$ cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/tmp/install
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Check for working C compiler: /usr/local/bin/cc
-- Check for working C compiler: /usr/local/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/local/bin/c++
-- Check for working CXX compiler: /usr/local/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/conan/project/build
$ cmake --build build --target install 
Scanning dependencies of target miniscript-cpp
make[2]: Warning: File 'CMakeFiles/miniscript-cpp.dir/depend.make' has modification time 0.19 s in the future
[  3%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/Dictionary.cpp.o
[  7%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/List.cpp.o
[ 11%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptInterpreter.cpp.o
[ 14%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptIntrinsics.cpp.o
[ 18%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptKeywords.cpp.o
[ 22%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptLexer.cpp.o
[ 25%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptParser.cpp.o
[ 29%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptTAC.cpp.o
[ 33%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptTypes.cpp.o
[ 37%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/QA.cpp.o
[ 40%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/SimpleString.cpp.o
[ 44%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/SimpleVector.cpp.o
[ 48%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/SplitJoin.cpp.o
[ 51%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/UnicodeUtil.cpp.o
[ 55%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/UnitTest.cpp.o
[ 59%] Linking CXX static library libminiscript-cpp.a
make[2]: warning:  Clock skew detected.  Your build may be incomplete.
[ 59%] Built target miniscript-cpp
Scanning dependencies of target minicmd
make[2]: Warning: File 'CMakeFiles/minicmd.dir/depend.make' has modification time 0.18 s in the future
[ 62%] Building CXX object CMakeFiles/minicmd.dir/MiniScript-cpp/src/main.cpp.o
[ 66%] Building CXX object CMakeFiles/minicmd.dir/MiniScript-cpp/src/DateTimeUtils.cpp.o
[ 70%] Building CXX object CMakeFiles/minicmd.dir/MiniScript-cpp/src/Key.cpp.o
[ 74%] Building CXX object CMakeFiles/minicmd.dir/MiniScript-cpp/src/OstreamSupport.cpp.o
[ 77%] Building CXX object CMakeFiles/minicmd.dir/MiniScript-cpp/src/ShellIntrinsics.cpp.o
[ 81%] Building CXX object CMakeFiles/minicmd.dir/MiniScript-cpp/src/ShellExec.cpp.o
[ 85%] Building C object CMakeFiles/minicmd.dir/MiniScript-cpp/src/whereami/whereami.c.o
[ 88%] Building C object CMakeFiles/minicmd.dir/MiniScript-cpp/src/editline/complete.c.o
[ 92%] Building C object CMakeFiles/minicmd.dir/MiniScript-cpp/src/editline/editline.c.o
[ 96%] Building C object CMakeFiles/minicmd.dir/MiniScript-cpp/src/editline/sysunix.c.o
[100%] Linking CXX executable miniscript
make[2]: warning:  Clock skew detected.  Your build may be incomplete.
[100%] Built target minicmd
Install the project...
-- Install configuration: ""
-- Installing: /tmp/install/lib/libminiscript-cpp.a
-- Installing: /tmp/install/bin/miniscript
```

When consuming the installed artifacts, it will not be able to point at same folder are include directory. This PR updates the CMakeLists.txt, following the possibility customize the folders for installation, for both libraries and application, plus, installing the headers.


```
$ cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/tmp/install
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Check for working C compiler: /usr/local/bin/cc
-- Check for working C compiler: /usr/local/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/local/bin/c++
-- Check for working CXX compiler: /usr/local/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/conan/project/build
$ cmake --build build --target install 
Scanning dependencies of target miniscript-cpp
make[2]: Warning: File 'CMakeFiles/miniscript-cpp.dir/depend.make' has modification time 0.19 s in the future
[  3%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/Dictionary.cpp.o
[  7%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/List.cpp.o
[ 11%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptInterpreter.cpp.o
[ 14%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptIntrinsics.cpp.o
[ 18%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptKeywords.cpp.o
[ 22%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptLexer.cpp.o
[ 25%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptParser.cpp.o
[ 29%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptTAC.cpp.o
[ 33%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/MiniscriptTypes.cpp.o
[ 37%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/QA.cpp.o
[ 40%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/SimpleString.cpp.o
[ 44%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/SimpleVector.cpp.o
[ 48%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/SplitJoin.cpp.o
[ 51%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/UnicodeUtil.cpp.o
[ 55%] Building CXX object CMakeFiles/miniscript-cpp.dir/MiniScript-cpp/src/MiniScript/UnitTest.cpp.o
[ 59%] Linking CXX static library libminiscript-cpp.a
make[2]: warning:  Clock skew detected.  Your build may be incomplete.
[ 59%] Built target miniscript-cpp
Scanning dependencies of target minicmd
make[2]: Warning: File 'CMakeFiles/minicmd.dir/depend.make' has modification time 0.18 s in the future
[ 62%] Building CXX object CMakeFiles/minicmd.dir/MiniScript-cpp/src/main.cpp.o
[ 66%] Building CXX object CMakeFiles/minicmd.dir/MiniScript-cpp/src/DateTimeUtils.cpp.o
[ 70%] Building CXX object CMakeFiles/minicmd.dir/MiniScript-cpp/src/Key.cpp.o
[ 74%] Building CXX object CMakeFiles/minicmd.dir/MiniScript-cpp/src/OstreamSupport.cpp.o
[ 77%] Building CXX object CMakeFiles/minicmd.dir/MiniScript-cpp/src/ShellIntrinsics.cpp.o
[ 81%] Building CXX object CMakeFiles/minicmd.dir/MiniScript-cpp/src/ShellExec.cpp.o
[ 85%] Building C object CMakeFiles/minicmd.dir/MiniScript-cpp/src/whereami/whereami.c.o
[ 88%] Building C object CMakeFiles/minicmd.dir/MiniScript-cpp/src/editline/complete.c.o
[ 92%] Building C object CMakeFiles/minicmd.dir/MiniScript-cpp/src/editline/editline.c.o
[ 96%] Building C object CMakeFiles/minicmd.dir/MiniScript-cpp/src/editline/sysunix.c.o
[100%] Linking CXX executable miniscript
make[2]: warning:  Clock skew detected.  Your build may be incomplete.
[100%] Built target minicmd
Install the project...
-- Install configuration: ""
-- Installing: /tmp/install/lib/libminiscript-cpp.a
-- Installing: /tmp/install/bin/miniscript
-- Installing: /tmp/install/include/MiniScript/Dictionary.h
-- Installing: /tmp/install/include/MiniScript/List.h
-- Installing: /tmp/install/include/MiniScript/MiniscriptErrors.h
-- Installing: /tmp/install/include/MiniScript/MiniscriptInterpreter.h
-- Installing: /tmp/install/include/MiniScript/MiniscriptIntrinsics.h
-- Installing: /tmp/install/include/MiniScript/MiniscriptKeywords.h
-- Installing: /tmp/install/include/MiniScript/MiniscriptLexer.h
-- Installing: /tmp/install/include/MiniScript/MiniscriptParser.h
-- Installing: /tmp/install/include/MiniScript/MiniscriptTAC.h
-- Installing: /tmp/install/include/MiniScript/MiniscriptTypes.h
-- Installing: /tmp/install/include/MiniScript/QA.h
-- Installing: /tmp/install/include/MiniScript/RefCountedStorage.h
-- Installing: /tmp/install/include/MiniScript/SimpleString.h
-- Installing: /tmp/install/include/MiniScript/SimpleVector.h
-- Installing: /tmp/install/include/MiniScript/SplitJoin.h
-- Installing: /tmp/install/include/MiniScript/UnicodeUtil.h
-- Installing: /tmp/install/include/MiniScript/UnitTest.h
```