### PR TITLE
Prevent accidental discard of line content during file.readLines

### DIFF
--- a/MiniScript-cpp/src/ShellIntrinsics.cpp
+++ b/MiniScript-cpp/src/ShellIntrinsics.cpp
@@ -749,7 +749,7 @@ static IntrinsicResult intrinsic_readLines(Context *context, IntrinsicResult par
 			}
 		}
 		if (lineStart < bytesRead) {
-			partialLine = String(&buf[lineStart], bytesRead - lineStart);
+			partialLine += String(&buf[lineStart], bytesRead - lineStart);
 		}
 	}
 	if (!partialLine.empty()) list.Add(partialLine);


### PR DESCRIPTION
file.readLines reads chunks of 1024 bytes, looking for newline characters. If we have content at the end of a chunk that isn't a newline, we store that content in a variable called `partialLine`.

However, if an entire chunk goes by without a newline (say, there's a line with >1024 characters), then ideally, we should append the chunk to the stored `partialLine`. However, we were instead *replacing* `partialLine` with the new chunk, accidentally discarding whatever was in `partialLine` before. It's an easy bug to miss, and simply swapping `partialLine =` with `partialLine +=` fixes the issue perfectly.

Fixes #190.