### PR TITLE
Fix reorder-ctor warning when building MiniScript-cpp

### DIFF
--- a/MiniScript-cpp/src/MiniScript/MiniscriptInterpreter.cpp
+++ b/MiniScript-cpp/src/MiniScript/MiniscriptInterpreter.cpp
@@ -12,18 +12,18 @@
 
 namespace MiniScript {
 	
-	Interpreter::Interpreter() : standardOutput(nullptr), errorOutput(nullptr), implicitOutput(nullptr),
-								parser(nullptr), vm(nullptr), hostData(nullptr) {
+	Interpreter::Interpreter() : standardOutput(nullptr), implicitOutput(nullptr), errorOutput(nullptr),
+								hostData(nullptr), vm(nullptr), parser(nullptr) {
 		
 	}
 
-	Interpreter::Interpreter(String source) : standardOutput(nullptr), errorOutput(nullptr), implicitOutput(nullptr),
-	parser(nullptr), vm(nullptr), hostData(nullptr) {
+	Interpreter::Interpreter(String source) : standardOutput(nullptr), implicitOutput(nullptr), errorOutput(nullptr),
+									hostData(nullptr), vm(nullptr), parser(nullptr) {
 		Reset(source);
 	}
 	
-	Interpreter::Interpreter(List<String> source) : standardOutput(nullptr), errorOutput(nullptr), implicitOutput(nullptr),
-	parser(nullptr), vm(nullptr), hostData(nullptr) {
+	Interpreter::Interpreter(List<String> source) : standardOutput(nullptr), implicitOutput(nullptr), errorOutput(nullptr),
+										hostData(nullptr), vm(nullptr), parser(nullptr) {
 		Reset(source);
 	}
 

--- a/MiniScript-cpp/src/MiniScript/MiniscriptTAC.cpp
+++ b/MiniScript-cpp/src/MiniScript/MiniscriptTAC.cpp
@@ -639,7 +639,7 @@ namespace MiniScript {
 //
 //	}
 	
-	Machine::Machine(Context *root, TextOutputMethod output) : stack(16), storeImplicit(false), standardOutput(output), startTime(0), yielding(false) {
+	Machine::Machine(Context *root, TextOutputMethod output) : standardOutput(output), storeImplicit(false), yielding(false), stack(16), startTime(0) {
 		// Note: this constructor adopts the given context, and destroys it later.
 		root->vm = this;
 		stack.Add(root);


### PR DESCRIPTION
Discovered these warnings while building MSRLWeb. Basically, the issue is that initializers run in order of their definition in the `class` and not the order they're given on the constructor, so, for example, you might think this:

```cpp
class Foo {
public:
    Foo() : baz(0), bar(baz) {}
    int bar;
    int baz;
};
```

Would initialize `bar` and `baz` to 0, but in reality, `bar` is initialized first with whatever uninitialized value is in `baz`, followed by `baz` being initialized to 0. In theory, this warning doesn't mean anything for MiniScript (both instances of this warning are for values being initialized to static values), but it doesn't cost much more than a few minutes of my time to fix this so that this warning doesn't appear when building a project with MiniScript.